### PR TITLE
PR: Added upstream-messaging for the Chrome extension

### DIFF
--- a/chrome/app.js
+++ b/chrome/app.js
@@ -219,13 +219,16 @@ function unregisterCallback() {
 function sendUpstream() {
   var msgContent = document.getElementById('upsterammsg').value;
   var error = document.getElementById('jsonError');
-
   var rawJson = document.getElementById('rawJson').checked;
-
 
   error.style.display = 'none';
   if (msgContent.length > 0) {
-    var data = {};
+    
+    var data = {
+      action: upsteramMessage,
+      message: msgContent
+    };
+
     if (rawJson) {
       try {
         data = JSON.parse(msgContent);
@@ -233,14 +236,9 @@ function sendUpstream() {
         error.style.display = 'inline';
         return;
       }
-    } else {
-      data = {
-        action: upsteramMessage,
-        message: msgContent
-      };
     }
-    var message = buildMessagePayload(data);
 
+    var message = buildMessagePayload(data);
     chrome.gcm.send(message, function(messageId) {
       console.log(messageId);
     });

--- a/chrome/app.js
+++ b/chrome/app.js
@@ -14,6 +14,7 @@
 
 var registerNewClient = "register_new_client";
 var unregisterClient = "unregister_client";
+var upsteramMessage = "upstream_message";
 
 var registrationToken = '';
 
@@ -42,6 +43,7 @@ function handleAlreadyRegistered() {
     setStatus('Already registered. Registration token:\n' + registrationToken);
     document.getElementById('register').disabled = true;
     document.getElementById('unregister').disabled = false;
+    document.getElementById('upstream').disabled = false;
   });
 }
 
@@ -52,6 +54,7 @@ function handleAlreadyRegistered() {
 function disableButtons() {
   document.getElementById('register').disabled = true;
   document.getElementById('unregister').disabled = true;
+  document.getElementById('upstream').disabled = true;
 }
 
 
@@ -158,6 +161,7 @@ function registerCallback(regToken) {
   if (chrome.runtime.lastError) {
     // Registration failed, handle the error and retry later.
     document.getElementById('register').disabled = false;
+    ocument.getElementById('upstream').disabled = false;
     return setStatus('FAILED: ' + chrome.runtime.lastError.message);
   }
 
@@ -173,9 +177,11 @@ function registerCallback(regToken) {
       chrome.storage.local.set({ regToken: registrationToken });
       document.getElementById('register').disabled = true;
       document.getElementById('unregister').disabled = false;
+      document.getElementById('upstream').disabled = false;
     } else {
       setAppServerStatus('Registration with app server FAILED: ' + err);
       document.getElementById('register').disabled = false;
+      ocument.getElementById('upstream').disabled = true;
     }
   });
 }
@@ -187,6 +193,7 @@ function registerCallback(regToken) {
 function unregisterCallback() {
   document.getElementById('register').disabled = false;
   document.getElementById('unregister').disabled = true;
+  document.getElementById('upstream').disabled = true;
 
   if (chrome.runtime.lastError) {
     return setStatus('FAILED: ' + chrome.runtime.lastError.message);
@@ -206,10 +213,44 @@ function unregisterCallback() {
   });
 }
 
+/**
+ * Sends an upsteram JSON message.  
+ */
+function sendUpstream() {
+  var msgContent = document.getElementById('upsterammsg').value;
+  var error = document.getElementById('jsonError');
+
+  var rawJson = document.getElementById('rawJson').checked;
+
+
+  error.style.display = 'none';
+  if (msgContent.length > 0) {
+    var data = {};
+    if (rawJson) {
+      try {
+        data = JSON.parse(msgContent);
+      } catch (e) {
+        error.style.display = 'inline';
+        return;
+      }
+    } else {
+      data = {
+        action: upsteramMessage,
+        message: msgContent
+      };
+    }
+    var message = buildMessagePayload(data);
+
+    chrome.gcm.send(message, function(messageId) {
+      console.log(messageId);
+    });
+  }
+}
 
 window.onload = function() {
   document.getElementById('register').onclick = register;
   document.getElementById('unregister').onclick = unregister;
+  document.getElementById('upstream').onclick = sendUpstream;
 
   chrome.gcm.onMessage.addListener(function(message) {
     console.log('chrome.gcm.onMessage', message);
@@ -223,6 +264,7 @@ window.onload = function() {
       setStatus('Put your sender ID above and click Register.');
       document.getElementById('register').disabled = false;
       document.getElementById('unregister').disabled = true;
+      document.getElementById('upstream').disabled = true;
     }
   });
 

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -17,8 +17,8 @@ var appWindow = null;
 function createWindow() {
   chrome.app.window.create(
     'index.html', {
-      width: 600,
-      height: 800,
+      width: 1000,
+      height: 700,
       frame: 'chrome',
       resizable: true
     },

--- a/chrome/index.html
+++ b/chrome/index.html
@@ -19,7 +19,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>GCM Playground Receiver</title>
+  <title>GCM Playground</title>
 
   <link rel="stylesheet" href="/mdl/material.min.css">
   <script src="/mdl/material.min.js"></script>
@@ -30,48 +30,72 @@
       padding: 20px;
     }
     .mdl-textfield {
-      width: 500px;
+      width: 90%;
     }
   </style>
 
 </head>
 <body>
 
-  <h4>GCM Playground Receiver</h4>
-
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-    <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="senderId" />
-    <label class="mdl-textfield__label" for="senderId">Sender ID (Project ID)</label>
-    <span class="mdl-textfield__error">Input is not a number!</span>
-  </div>
-
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-    <input class="mdl-textfield__input" type="text" id="stringIdentifier" />
-    <label class="mdl-textfield__label" for="stringIdentifier">String Identifier (Optional)</label>
-  </div>
+  <h4>GCM Playground</h4>
 
   <div class="mdl-grid">
-    <div class="mdl-cell mdl-cell--6-cols">
-      <button id="register" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Register</button>
+    <div class="mdl-cell mdl-cell--4-col">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="senderId" />
+        <label class="mdl-textfield__label" for="senderId">Sender ID (Project ID)</label>
+        <span class="mdl-textfield__error">Input is not a number!</span>
+      </div>
     </div>
-    <div class="mdl-cell mdl-cell--6-cols">
+    <div class="mdl-cell mdl-cell--4-col">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="text" id="stringIdentifier" />
+        <label class="mdl-textfield__label" for="stringIdentifier">String Identifier (Optional)</label>
+      </div>
+    </div>
+    <div class="mdl-cell mdl-cell--4-col">
+      <button id="register" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Register</button>
+      &nbsp;
       <button id="unregister" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Unregister</button>
     </div>
   </div>
-
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-    <textarea class="mdl-textfield__input" type="text" id="appServerStatus" rows="2" cols="65"></textarea>
-    <label class="mdl-textfield__label" for="appServerStatus">App Server Registration Status</label>
+    <div class="mdl-grid">
+    <div class="mdl-cell mdl-cell--6-col">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <textarea class="mdl-textfield__input" type="text" id="appServerStatus" rows="2" cols="65"></textarea>
+        <label class="mdl-textfield__label" for="appServerStatus">App Server Registration Status</label>
+      </div>
+    </div>
+    <div class="mdl-cell mdl-cell--6-col">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label is-focused">
+        <textarea class="mdl-textfield__input" type="text" id="status" rows="4" cols="65"></textarea>
+        <label class="mdl-textfield__label" for="status">GCM Registration Status</label>
+      </div>
+    </div>
+    
   </div>
-
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label is-focused">
-    <textarea class="mdl-textfield__input" type="text" id="status" rows="4" cols="65"></textarea>
-    <label class="mdl-textfield__label" for="status">GCM Registration Status</label>
-  </div>
-
-  <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label is-focused">
-    <textarea class="mdl-textfield__input" type="text" id="message" rows="5" cols="65"></textarea>
-    <label class="mdl-textfield__label" for="message">Message Received</label>
+<hr>
+<div>
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label is-focused">
+        <textarea class="mdl-textfield__input" type="text" id="message" rows="2" cols="65"></textarea>
+        <label class="mdl-textfield__label" for="message">Downstream Message Received</label>
+      </div>
+</div>
+<hr>
+  <div class="mdl-grid">
+    <div class="mdl-cell mdl-cell--10-col">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label is-focused">
+        <textarea class="mdl-textfield__input" type="text" id="upsterammsg" rows="5" cols="80"></textarea>
+        <label class="mdl-textfield__label" for="upsterammsg">Upstream Message Content</label>
+      </div>
+      <label class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect" for="rawJson">
+        <input type="checkbox" id="rawJson" class="mdl-checkbox__input">
+        <span class="mdl-checkbox__label">JSON payload</span> <span style="display:none; color: red;" id="jsonError">JSON was invalid!  Not sent.</span>
+      </label>
+    </div>
+    <div class="mdl-cell mdl-cell--2-col">
+      <button id="upstream" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Send Upstream</button>
+    </div>
   </div>
 
 </body>

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "GCM Playground Receiver",
+  "name": "GCM Playground",
   "version": "0.0.1",
-  "description": "GCM Playground Receiver",
+  "description": "GCM Playground",
   "manifest_version": 2,
   "permissions": [
     "gcm",


### PR DESCRIPTION
Hi,

I needed to test upstream messaging for something I am working on, but the Chrome extension was only downstream so I've added upstream messaging support for the extension (and also fiddled around with the UI a little bit to fit it all in nicely).

Also, as a minor point I changed the name of the extension form "GCM Playground Receiver" to just "GCM Playground" since that seemed to make more sense now that it can both receive and send.

Thanks,
mattdibb@