### PR TITLE
Gorm db.Open returns a pointer to db.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -59,7 +59,7 @@ var (
 	debug = true
 
 	// Current database connection
-	db gorm.DB
+	db *gorm.DB
 
 	// Websocket connection
 	socket socketio.Socket


### PR DESCRIPTION
https://github.com/jinzhu/gorm/commit/f574429f5ec8bcaa984ca5edeb242bb552eba167

Gcm db.Open target was not expecting a pointer to the db struct returned by
gorm causing it to error.

--Before:
$ go build server.go
./server.go:96: cannot assign *gorm.DB to db (type gorm.DB) in multiple assignment

--After:
$ go build server.go
$